### PR TITLE
Integrate CompileState into the testframework

### DIFF
--- a/Core/ProtoAssociative/CodeGen.cs
+++ b/Core/ProtoAssociative/CodeGen.cs
@@ -2576,6 +2576,19 @@ namespace ProtoAssociative
                 // Get the replication guide from the dotcall
                 replicationGuides = exprList.ReplicationGuides;
             }
+            else if (node is RangeExprNode)
+            {
+                RangeExprNode rangeExpr = node as RangeExprNode;
+
+                // Get the replication guide from the dotcall
+                replicationGuides = rangeExpr.ReplicationGuides;
+            }
+            else if (node is InlineConditionalNode)
+            {
+                // TODO Jun: Parser should support replication guides on an entire inline conditional
+                InlineConditionalNode inlineCondition = node as InlineConditionalNode;
+                replicationGuides = null;
+            }
             else
             {
                 // A parser error has occured if a replication guide gets attached to any AST besides"

--- a/Core/ProtoCore/BuildStatus.cs
+++ b/Core/ProtoCore/BuildStatus.cs
@@ -500,11 +500,6 @@ namespace ProtoCore
 
         public void LogSemanticError(string msg, string fileName = null, int line = -1, int col = -1, AssociativeGraph.GraphNode graphNode = null)
         {
-            /*if (fileName == null)
-            {
-                fileName = "N.A.";
-            }*/
-
             if (logErrors)
             {
                 System.Console.WriteLine("{0}({1},{2}) Error:{3}", fileName, line, col, msg);
@@ -523,16 +518,6 @@ namespace ProtoCore
                 Col = col
             };
             errors.Add(errorEntry);
-
-            // Comment: This is true for example in Graph Execution mode
-            /*if (errorAsWarning)
-            {
-                if (graphNode != null)
-                {
-                    graphNode.isDirty = false;
-                    return;
-                }
-            }*/
 
             OutputMessage outputmessage = new OutputMessage(OutputMessage.MessageType.Error, msg.Trim(), fileName, line, col);
             if (MessageHandler != null)

--- a/Core/ProtoCore/Core.cs
+++ b/Core/ProtoCore/Core.cs
@@ -939,7 +939,6 @@ namespace ProtoCore
         public List<Instruction> Breakpoints { get; set; }
 
         public Options Options { get; private set; }
-        public BuildStatus BuildStatus { get; private set; }
         public RuntimeStatus RuntimeStatus { get; private set; }
 
         public TypeSystem TypeSystem { get; set; }
@@ -1487,7 +1486,6 @@ namespace ProtoCore
             secondCore.AssocNode = AssocNode;
             secondCore.BaseOffset = BaseOffset;
             secondCore.Breakpoints = new List<Instruction>(Breakpoints);
-            secondCore.BuildStatus = BuildStatus; //For now just retarget the build infomration to same output
 
             //@TODO(Luke) Should these be deep cloned? They will need to be fixed before we do any form of dynamic
             //code injection

--- a/Core/ProtoCore/FFI/CLRFFIFunctionPointer.cs
+++ b/Core/ProtoCore/FFI/CLRFFIFunctionPointer.cs
@@ -326,9 +326,9 @@ namespace ProtoFFI
             {
                 if (ex.InnerException != null)
                 {
-                    dsi.LogSemanticError(ex.InnerException.Message);
+                    dsi.LogError(ex.InnerException.Message);
                 }
-                dsi.LogSemanticError(ex.Message);
+                dsi.LogError(ex.Message);
             }
             catch (System.Reflection.TargetException ex)
             {
@@ -398,9 +398,9 @@ namespace ProtoFFI
             {
                 if (ex.InnerException != null)
                 {
-                    dsi.LogSemanticError(ErrorString(ex.InnerException));
+                    dsi.LogError(ErrorString(ex.InnerException));
                 }
-                dsi.LogSemanticError(ErrorString(ex));
+                dsi.LogError(ErrorString(ex));
             }
 
             return dsRetValue;

--- a/Core/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
+++ b/Core/ProtoCore/Lang/BuiltInFunctionEndPoint.cs
@@ -1041,11 +1041,11 @@ namespace ProtoCore.Lang
             //For IDE output
             ProtoCore.Core core = runtime.runtime.Core;
             OutputMessage t_output = new OutputMessage(result);
-            core.BuildStatus.MessageHandler.Write(t_output);
-            if (core.Options.WebRunner)
-            {
-                core.BuildStatus.WebMsgHandler.Write(t_output);
-            }
+            //core.BuildStatus.MessageHandler.Write(t_output);
+            //if (core.Options.WebRunner)
+            //{
+            //    core.BuildStatus.WebMsgHandler.Write(t_output);
+            //}
             return DSASM.StackUtils.BuildNull();
         }
     }

--- a/Core/ProtoCore/Utils/CoreUtils.cs
+++ b/Core/ProtoCore/Utils/CoreUtils.cs
@@ -386,10 +386,16 @@ namespace ProtoCore.Utils
             core.RuntimeStatus.LogWarning(id, msg, fileName, line, col);
         }
 
-        public static void LogSemanticError(this Interpreter dsi, string msg, string fileName = null, int line = -1, int col = -1)
+        //public static void LogSemanticError(this Interpreter dsi, string msg, string fileName = null, int line = -1, int col = -1)
+        //{
+        //    ProtoCore.Core core = dsi.runtime.Core;
+        //    core.BuildStatus.LogSemanticError(msg, fileName, line, col);
+        //}
+
+        public static void LogError(this Interpreter dsi, string msg, string fileName = null, int line = -1, int col = -1)
         {
             ProtoCore.Core core = dsi.runtime.Core;
-            core.BuildStatus.LogSemanticError(msg, fileName, line, col);
+            core.RuntimeStatus.LogWarning(ProtoCore.RuntimeData.WarningID.kDefault, msg, fileName, line, col);
         }
 
         public static void LogWarning(this Core core, ProtoCore.RuntimeData.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
@@ -397,15 +403,15 @@ namespace ProtoCore.Utils
             core.RuntimeStatus.LogWarning(id, msg, fileName, line, col);
         }
 
-        public static void LogWarning(this Core core, ProtoCore.BuildData.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
-        {
-            core.BuildStatus.LogWarning(id, msg, fileName, line, col);
-        }
+        //public static void LogWarning(this Core core, ProtoCore.BuildData.WarningID id, string msg, string fileName = null, int line = -1, int col = -1)
+        //{
+        //    core.BuildStatus.LogWarning(id, msg, fileName, line, col);
+        //}
 
-        public static void LogSemanticError(this Core core, string msg, string fileName = null, int line = -1, int col = -1)
-        {
-            core.BuildStatus.LogSemanticError(msg, fileName, line, col);
-        }
+        //public static void LogSemanticError(this Core core, string msg, string fileName = null, int line = -1, int col = -1)
+        //{
+        //    core.BuildStatus.LogSemanticError(msg, fileName, line, col);
+        //}
 
 
         public static string GenerateIdentListNameString(ProtoCore.AST.AssociativeAST.AssociativeNode node)

--- a/Core/ProtoScript/Runners/LiveRunner.cs
+++ b/Core/ProtoScript/Runners/LiveRunner.cs
@@ -478,12 +478,11 @@ namespace ProtoScript.Runners
             private void ReportBuildErrorsAndWarnings(string code, SynchronizeData syncDataReturn, Dictionary<uint, string> modifiedGuidList, ref GraphUpdateReadyEventArgs retArgs)
             {
                 //GraphUpdateReadyEventArgs retArgs = null;
-
-                if (runner.runnerCore.BuildStatus.ErrorCount > 0)
+                if (runner.compileState.BuildStatus.ErrorCount > 0)
                 {
                     retArgs = new GraphUpdateReadyEventArgs(syncDataReturn);
 
-                    foreach (var err in runner.runnerCore.BuildStatus.Errors)
+                    foreach (var err in runner.compileState.BuildStatus.Errors)
                     {
                         string msg = err.Message;
                         int lineNo = err.Line;
@@ -522,12 +521,12 @@ namespace ProtoScript.Runners
                         }
                     }
                 }
-                if (runner.runnerCore.BuildStatus.WarningCount > 0)
+                if (runner.compileState.BuildStatus.WarningCount > 0)
                 {
                     if (retArgs == null)
                         retArgs = new GraphUpdateReadyEventArgs(syncDataReturn);
 
-                    foreach (var warning in runner.runnerCore.BuildStatus.Warnings)
+                    foreach (var warning in runner.compileState.BuildStatus.Warnings)
                     {
                         string msg = warning.msg;
                         int lineNo = warning.line;

--- a/Core/ProtoScript/Runners/LiveRunner.cs
+++ b/Core/ProtoScript/Runners/LiveRunner.cs
@@ -879,6 +879,7 @@ namespace ProtoScript.Runners
             //Validity.Assert(coreOptions.IsDeltaExecution && !coreOptions.GenerateExprID);
 
             runnerCore = new ProtoCore.Core(coreOptions);
+            compileState = ProtoScript.CompilerUtils.BuildDefaultCompilerState();
             
             SyncCoreConfigurations(runnerCore, executionOptions);
 
@@ -1273,7 +1274,7 @@ namespace ProtoScript.Runners
             ProtoCore.Runtime.Context runtimeContext = new ProtoCore.Runtime.Context();
             runtimeContext.execFlagList = graphCompiler.ExecutionFlagList;
 
-            runner.Execute(runnerCore, runtimeContext, null);
+            runner.Execute(runnerCore, runtimeContext, compileState);
 
             return new ProtoRunner.ProtoVMState(runnerCore);
         }

--- a/Tests/ProtoTest/Associative/MethodResolution.cs
+++ b/Tests/ProtoTest/Associative/MethodResolution.cs
@@ -9,6 +9,7 @@ namespace ProtoTest.Associative
     class MethodResolution
     {
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState = null;
         public TestFrameWork thisTest = new TestFrameWork();
 
         [SetUp]
@@ -43,7 +44,7 @@ namespace ProtoTest.Associative
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 123);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 345);
@@ -84,7 +85,7 @@ namespace ProtoTest.Associative
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 123);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 345);
@@ -142,7 +143,7 @@ namespace ProtoTest.Associative
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 200);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 800);
@@ -189,7 +190,7 @@ d = s3.mx;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((double)mirror.GetValue("d").Payload == 1);
 
@@ -221,10 +222,10 @@ d = s3.mx;
                 val = b.execute(a);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -257,10 +258,10 @@ d = s3.mx;
                 val = b.execute(c);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -292,10 +293,10 @@ d = s3.mx;
                 val = c.execute(c);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -327,10 +328,10 @@ d = s3.mx;
                 val = c.execute(c);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 2);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -358,10 +359,10 @@ d = s3.mx;
                 val = c.execute(c);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -390,10 +391,10 @@ d = s3.mx;
                 val = b.execute(arr);
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 2);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -500,12 +501,12 @@ d = s3.mx;
                 val3 = val[2];
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val1").Payload == -1);
             Assert.IsTrue((Int64)mirror.GetValue("val2").Payload == -1);
             Assert.IsTrue((Int64)mirror.GetValue("val3").Payload == -1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
 
@@ -538,11 +539,11 @@ d = s3.mx;
                 val2 = val[1];
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val1").Payload == -1);
             Assert.IsTrue((Int64)mirror.GetValue("val2").Payload == -1);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -566,10 +567,10 @@ v = A.execute(arr);
 val = v[0];
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 100);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -591,10 +592,10 @@ v = A.execute(arr);
 val = v[0];
                 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             //Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 100);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -688,10 +689,10 @@ val = v[0];
                             val = Test(a);
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 123);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -715,10 +716,10 @@ val = v[0];
                             val = Test(a);
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 123);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -742,10 +743,10 @@ val = v[0];
                             val = A.A().foo(arr);
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 2);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -769,10 +770,10 @@ val = v[0];
                             val = A.A().foo(arr);
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val").Payload == 2);
-            Assert.IsTrue(core.BuildStatus.WarningCount == 0);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == 0);
         }
 
         [Test]
@@ -802,7 +803,7 @@ val = v[0];
 
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("val1").Payload == 1);
             //Assert.IsTrue((Int64)mirror.GetValue("val2").Payload == 2);
@@ -834,7 +835,7 @@ val = v[0];
 
                             ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             //Assert.IsTrue((Int64)mirror.GetValue("val1").Payload == 1);
             Assert.IsTrue((Int64)mirror.GetValue("val2").Payload == 2);

--- a/Tests/ProtoTest/Associative/RedefinitionExpression.cs
+++ b/Tests/ProtoTest/Associative/RedefinitionExpression.cs
@@ -11,6 +11,7 @@ namespace ProtoTest.Associative
         public TestFrameWork thisTest = new TestFrameWork();
 
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState;
 
         [SetUp]
         public void Setup()
@@ -35,7 +36,7 @@ x = 1000;
 x = f(x);
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 1001);
 
@@ -64,7 +65,7 @@ x = p.mx;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 11);
         }
@@ -96,7 +97,7 @@ x = p.f(x);
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 11);
         }
@@ -119,7 +120,7 @@ y = 10;
 x = f1(x, y) - f2(x, y); 
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 20);
 
         }
@@ -138,7 +139,7 @@ x = 2;
 x = f(x + f(x));
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 36);
 
         }
@@ -154,7 +155,7 @@ x = a[0];
 y = a[1];
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 1);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 2);
@@ -177,7 +178,7 @@ x = a[0];
 y = a[1];
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 1);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 2);
@@ -201,7 +202,7 @@ x = a[0];
 y = a[1];
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 7);
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 3);
         }

--- a/Tests/ProtoTest/DSASM/ExecutionMirrorTests.cs
+++ b/Tests/ProtoTest/DSASM/ExecutionMirrorTests.cs
@@ -9,6 +9,7 @@ namespace ProtoTest.Associative
     class ExecutionMirrorTests
     {
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState;
 
         [SetUp]
         public void Setup()
@@ -32,7 +33,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("foo");
             Assert.IsTrue((Int64)o.Payload == 5);
@@ -52,7 +53,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("foo");
             ProtoCore.DSASM.Mirror.DsasmArray a = (ProtoCore.DSASM.Mirror.DsasmArray)o.Payload;
@@ -75,7 +76,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("foo");
             ProtoCore.DSASM.Mirror.DsasmArray a = (ProtoCore.DSASM.Mirror.DsasmArray)o.Payload;
@@ -102,7 +103,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("foo");
             ProtoCore.DSASM.Mirror.DsasmArray a = (ProtoCore.DSASM.Mirror.DsasmArray)o.Payload;
@@ -133,7 +134,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("foo");
             ProtoCore.DSASM.Mirror.DsasmArray a = (ProtoCore.DSASM.Mirror.DsasmArray)o.Payload;
@@ -165,7 +166,7 @@ foo;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.Lang.Obj o = mirror.GetValue("foo");
             ProtoCore.DSASM.Mirror.DsasmArray a = (ProtoCore.DSASM.Mirror.DsasmArray)o.Payload;

--- a/Tests/ProtoTest/FFITests.cs
+++ b/Tests/ProtoTest/FFITests.cs
@@ -12,6 +12,7 @@ namespace ProtoTest
     public class FFITests
     {
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState = null;
 
         [SetUp]
         public void Setup()
@@ -46,8 +47,9 @@ namespace ProtoTest
             ProtoCore.Core core = new ProtoCore.Core(new ProtoCore.Options());
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
-
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            
+            ProtoLanguage.CompileStateTracker compileState = null;
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("a");
             Assert.IsTrue((Int64)o.Payload == 24);
@@ -68,7 +70,8 @@ namespace ProtoTest
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            fsr.Execute(scriptCode, core);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            fsr.Execute(scriptCode, core, out compileState);
         }
     }
 }

--- a/Tests/ProtoTest/FFITests/CSFFITest.cs
+++ b/Tests/ProtoTest/FFITests/CSFFITest.cs
@@ -50,9 +50,11 @@ namespace ProtoFFITests
         {
             ProtoCore.Core core = Setup();
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core, context);
+
+            ProtoLanguage.CompileStateTracker compileState = null;
+            ExecutionMirror mirror = fsr.Execute(code, core, context, out compileState);
             int nWarnings = core.RuntimeStatus.Warnings.Count;
-            nErrors = core.BuildStatus.ErrorCount;
+            nErrors = compileState.BuildStatus.ErrorCount;
             if (data == null)
             {
                 core.Cleanup();

--- a/Tests/ProtoTest/Imperative/FromOldTestSuite.cs
+++ b/Tests/ProtoTest/Imperative/FromOldTestSuite.cs
@@ -178,7 +178,8 @@ f0;f1;f2;f3;t0;t1;t2;t3;t4;t5;t6;t7;
 
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("y").Payload == 57);
         }

--- a/Tests/ProtoTest/MinimalClassTests.cs
+++ b/Tests/ProtoTest/MinimalClassTests.cs
@@ -34,7 +34,8 @@ size;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             Obj o = mirror.GetValue("size");
             Assert.IsTrue((Int64)o.Payload == 5);

--- a/Tests/ProtoTest/ModifierStack.cs
+++ b/Tests/ProtoTest/ModifierStack.cs
@@ -10,6 +10,7 @@ namespace ProtoTest
     public class ModifierStackTests
     {
         private ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState;
 
         [SetUp]
         public void Setup() 
@@ -36,7 +37,7 @@ namespace ProtoTest
                         {
                             a = 10;
                         }
-                        ", core);
+                        ", core, out compileState);
         }
 
         [Test]
@@ -54,7 +55,7 @@ namespace ProtoTest
                             }
                             x = foo(2);
                         }
-                        ", core);
+                        ", core, out compileState);
         }
 
         [Test]
@@ -72,7 +73,7 @@ a;
                                     10;
                                 }
                         }
-                        ", core);
+                        ", core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("a", 0).Payload == 10);
             
         }
@@ -93,7 +94,7 @@ a;
                                     20;
                                 }
                         }
-                        ", core);
+                        ", core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("a", 0).Payload == 20);
         }
 
@@ -114,7 +115,7 @@ a;
                                     *2;
                                 }
                         }
-                        ", core);
+                        ", core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("a", 0).Payload == 60);
         }
         
@@ -137,7 +138,7 @@ a;a@init;
                                 *2;
                                  }
                         }
-                        ", core);
+                        ", core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("a@init", 0).Payload == 2);
             Assert.IsTrue((Int64)mirror.GetValue("a", 0).Payload == 6);
         }
@@ -160,7 +161,7 @@ a;a@init;a@first;
                                     *2;
                                 }
                         }
-                        ", core);
+                        ", core, out compileState);
             Assert.IsTrue((Int64)mirror.GetValue("a@init", 0).Payload == 3);
             Assert.IsTrue((Int64)mirror.GetValue("a@first", 0).Payload == 4);
             Assert.IsTrue((Int64)mirror.GetValue("a", 0).Payload == 16);
@@ -184,7 +185,7 @@ a@first;
                                     1 => a@first;
                                 }
                         }
-                        ", core);
+                        ", core, out compileState);
             
             Obj o = mirror.GetValue("a@init");
             List<Obj> os = mirror.GetArrayElements(o);
@@ -216,7 +217,7 @@ a@first;
                                      foo(7) => a@first;
                                  }
                          }
-                        ", core);
+                        ", core, out compileState);
 
             Obj o = mirror.GetValue("a@init");
             List<Obj> os = mirror.GetArrayElements(o);
@@ -251,7 +252,7 @@ a@first;
                                      foo(a@init) => a@first;
                                  }
                          }
-                        ", core);
+                        ", core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("a@init", 0).Payload == 8);
             Assert.IsTrue((Int64)mirror.GetValue("a@first", 0).Payload == 10);
@@ -278,7 +279,7 @@ a@first;
                                      foo(a@init) => a@first;
                                  }
                          }
-                        ", core);
+                        ", core, out compileState);
 
             Obj o = mirror.GetValue("a@init");
             List<Obj> os = mirror.GetArrayElements(o);
@@ -325,7 +326,7 @@ a@first;
                               }
                                 point = Point.Point(10,10,10);
                             }
-                            ", core);
+                            ", core, out compileState);
 
            //Object o = mirror.GetValue("point.mx");
            //Assert.IsTrue((long)o == 10);

--- a/Tests/ProtoTest/MultiLangTests/AssociativeToImperative.cs
+++ b/Tests/ProtoTest/MultiLangTests/AssociativeToImperative.cs
@@ -9,7 +9,8 @@ namespace ProtoTest.MultiLangTests
     [TestFixture]
     public class AssociativeToImperative
     {
-            public ProtoCore.Core core;
+        public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState;
 
             [SetUp]
             public void Setup()
@@ -35,7 +36,7 @@ namespace ProtoTest.MultiLangTests
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 5);
@@ -64,7 +65,7 @@ x;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 5);
@@ -93,7 +94,7 @@ x;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 6);
@@ -122,7 +123,7 @@ x;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 7); //0 => x@first, 1 x@second, 6 -> x@first 7 -> x@second
@@ -151,7 +152,7 @@ x;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 6);
@@ -172,7 +173,7 @@ x = c > 5 ? 1 : 2;
 }
                 ";
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("x").Payload == 1);
             }
@@ -193,7 +194,7 @@ a = 10;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
                 Obj o = mirror.GetValue("b");
                 Assert.IsTrue((Int64)o.Payload == 10);
             }
@@ -219,7 +220,7 @@ p.x = 10;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
                 Obj o = mirror.GetValue("a");
                 Assert.IsTrue((Int64)o.Payload == 10);
             }
@@ -248,7 +249,7 @@ a;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("a").Payload == 0);
 
@@ -278,7 +279,7 @@ a;
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("a").Payload == 1020);
 
@@ -304,7 +305,7 @@ a = f(16);
     
 ";
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("a").Payload == 48);
 
@@ -338,7 +339,7 @@ a = clampRange(101, 10, 100);
     
 ";
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("a").Payload == 100);
 
@@ -368,7 +369,7 @@ p = foo();
     
 ";
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("p").Payload == 6);
 
@@ -397,7 +398,7 @@ p = foo();
     
 ";
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Assert.IsTrue((Int64)mirror.GetValue("p").Payload == 6);
 
@@ -433,7 +434,7 @@ p = foo();
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
                 Assert.IsTrue((Int64)mirror.GetValue("w0").Payload == 100);
                 Assert.IsTrue((Int64)mirror.GetValue("w1").Payload == 200);
                 Assert.IsTrue((Int64)mirror.GetValue("w2").Payload == 300);
@@ -474,7 +475,7 @@ p = foo();
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
                 Assert.IsTrue((Int64)mirror.GetValue("p1").Payload == 6);
                 Assert.IsTrue((Int64)mirror.GetValue("p2").Payload == 6);
                 
@@ -519,7 +520,7 @@ p2 = foo2(); // expected 6, got 6
 ";
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
                 Assert.IsTrue((Int64)mirror.GetValue("p1").Payload == 6);
                 Assert.IsTrue((Int64)mirror.GetValue("p2").Payload == 6);
 

--- a/Tests/ProtoTest/MultiLanugageBasic.cs
+++ b/Tests/ProtoTest/MultiLanugageBasic.cs
@@ -8,6 +8,8 @@ namespace ProtoTest
     class MultiLanugageBasic
     {
 
+        private ProtoLanguage.CompileStateTracker compileState = null;
+
         [SetUp]
         public void TestSetup()
         {
@@ -30,7 +32,7 @@ namespace ProtoTest
     a = 3;
     b = 4;
 }
-", core);
+", core, out compileState);
        }
 
         [Test]
@@ -49,7 +51,7 @@ namespace ProtoTest
     a = 3;
     b = 4;
 }
-", core);
+", core, out compileState);
         }
 
         [Test]
@@ -71,7 +73,7 @@ namespace ProtoTest
         }
     b = 4;
 }
-", core);
+", core, out compileState);
         }
 
 
@@ -95,7 +97,7 @@ namespace ProtoTest
     }
     b = 4;
 }
-", core);
+", core, out compileState);
         }
 
         [Test]
@@ -126,7 +128,7 @@ namespace ProtoTest
     }
     c = a;
 }
-", core);
+", core, out compileState);
         }
 
         [Test]
@@ -158,7 +160,7 @@ x;y;
     y = p.m;
 }
 "
-    , core);
+    , core, out compileState);
 
             Assert.IsTrue((Int64)mirror.GetValue("x", 0).Payload == 16);
             Assert.IsTrue((Int64)mirror.GetValue("y", 0).Payload == 32);

--- a/Tests/ProtoTest/ProtoScriptTest.cs
+++ b/Tests/ProtoTest/ProtoScriptTest.cs
@@ -18,7 +18,7 @@ namespace ProtoTest
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
 
-
+            ProtoLanguage.CompileStateTracker compileState = null;
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
 
@@ -33,7 +33,7 @@ namespace ProtoTest
 		 px = 1234321;
 	}
 }
-", core);
+", core, out compileState);
         }
 
 
@@ -47,6 +47,7 @@ namespace ProtoTest
         [Test]
         public void ParserFailTest1()
         {
+            ProtoLanguage.CompileStateTracker compileState = null;
             ProtoCore.Core core = new ProtoCore.Core(new ProtoCore.Options());
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
@@ -63,13 +64,14 @@ namespace ProtoTest
 {
     a = 3
 }
-", core);
+", core, out compileState);
             });
         }
 
         [Test]
         public void ParserFailTest2()
         {
+            ProtoLanguage.CompileStateTracker compileState = null;
             ProtoCore.Core core = new ProtoCore.Core(new ProtoCore.Options());
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
@@ -87,13 +89,14 @@ namespace ProtoTest
 {
     a = 3
 }
-", core);
+", core, out compileState);
             });
         }
 
         [Test]
         public void ParserFailTest3()
         {
+            ProtoLanguage.CompileStateTracker compileState = null;
             ProtoCore.Core core = new ProtoCore.Core(new ProtoCore.Options());
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
             core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
@@ -112,7 +115,7 @@ namespace ProtoTest
 	a = 1;
 	
 }
-", core);
+", core, out compileState);
             });
         }
 

--- a/Tests/ProtoTest/RegressionTests/ProtoCoreLexerTests.cs
+++ b/Tests/ProtoTest/RegressionTests/ProtoCoreLexerTests.cs
@@ -9,6 +9,7 @@ namespace ProtoTest.RegressionTests
         public class LexerRegressionTests
         {
             public ProtoCore.Core core;
+            private ProtoLanguage.CompileStateTracker compileState = null;
 
             [SetUp]
             public void Setup()
@@ -36,7 +37,7 @@ namespace ProtoTest.RegressionTests
 
 
                 ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-                ExecutionMirror mirror = fsr.Execute(code, core);
+                ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
                 Obj o = mirror.GetValue("x");
                 Assert.IsTrue((Int64)o.Payload == 1001);

--- a/Tests/ProtoTest/TD/ArrayUtilsTest.cs
+++ b/Tests/ProtoTest/TD/ArrayUtilsTest.cs
@@ -12,6 +12,7 @@ namespace ProtoTest.UtilsTests
     public class ArrayUtilsTest
     {
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState = null;
 
         [SetUp]
         public void Setup()
@@ -37,7 +38,7 @@ namespace ProtoTest.UtilsTests
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -69,7 +70,7 @@ class A
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -101,7 +102,7 @@ class A
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -135,7 +136,7 @@ class A
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("b");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("c");
@@ -161,7 +162,7 @@ a;b;c;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
 
@@ -202,7 +203,7 @@ a;b;c;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -248,7 +249,7 @@ a;b;c;d;e;
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -328,7 +329,7 @@ tCCC = {C.C(), C.C(), C.C()};
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue svAAA = mirror.GetRawFirstValue("tAAA");
             ClassNode superAAA = ArrayUtils.GetGreatestCommonSubclassForArray(svAAA, core);
@@ -483,7 +484,7 @@ tCD = { c, d };
 
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue svABC = mirror.GetRawFirstValue("tABC");
             ClassNode superABC = ArrayUtils.GetGreatestCommonSubclassForArray(svABC, core);
@@ -547,7 +548,7 @@ tE = {};//empty array
 
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue svABC = mirror.GetRawFirstValue("tABC");
             ClassNode superABC = ArrayUtils.GetGreatestCommonSubclassForArray(svABC, core);
@@ -608,7 +609,7 @@ rBH = {b,h};
 
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue svABCDEF = mirror.GetRawFirstValue("rABCDEF");
             ClassNode superABCDEF = ArrayUtils.GetGreatestCommonSubclassForArray(svABCDEF, core);
@@ -639,7 +640,7 @@ rBH = {b,h};
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             ProtoCore.DSASM.StackValue svA = mirror.GetRawFirstValue("a");
             ProtoCore.DSASM.StackValue svB = mirror.GetRawFirstValue("b");
@@ -663,7 +664,7 @@ b = {1,2,{3}};
 x = {{1},{3.1415}};
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue a = mirror.GetRawFirstValue("a");
             StackValue b = mirror.GetRawFirstValue("b");
@@ -694,7 +695,7 @@ r2 = Contains(a, 3.0);
 //t = Contains(a, null);
 ";
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             StackValue a = mirror.GetRawFirstValue("a");
 

--- a/Tests/ProtoTest/UtilsTests/ClassUtilsTest.cs
+++ b/Tests/ProtoTest/UtilsTests/ClassUtilsTest.cs
@@ -13,6 +13,7 @@ namespace ProtoTest.UtilsTests
     public class ClassUtilsTest
     {
         public ProtoCore.Core core;
+        private ProtoLanguage.CompileStateTracker compileState = null;
 
         [SetUp]
         public void Setup()
@@ -38,7 +39,7 @@ class C extends B {}
 ";
 
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScript.Runners.ProtoScriptTestRunner();
-            ExecutionMirror mirror = fsr.Execute(code, core);
+            ExecutionMirror mirror = fsr.Execute(code, core, out compileState);
 
             int idA = core.ClassTable.IndexOf("A");
             int idB = core.ClassTable.IndexOf("B");

--- a/Tests/ProtoTest/UtilsTests/CoreDump.cs
+++ b/Tests/ProtoTest/UtilsTests/CoreDump.cs
@@ -13,6 +13,7 @@ namespace ProtoTest.UtilsTests
     public class CoreDumpTest
     {
         private ProtoCore.Core core = null;
+        private ProtoLanguage.CompileStateTracker compileState = null;
         private ProtoScriptTestRunner coreRunner = null;
 
         [SetUp]
@@ -40,7 +41,7 @@ namespace ProtoTest.UtilsTests
 
                 values = A.B(1..20..1);";
 
-            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core);
+            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core, out compileState);
             List<string> globalVariables = null;
             mirror.GetCoreDump(out globalVariables, 7, 4);
 
@@ -67,7 +68,7 @@ namespace ProtoTest.UtilsTests
                 over = A.B(1..9..1);
 ";
 
-            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core);
+            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core, out compileState);
             List<string> globalVariables = null;
             mirror.GetCoreDump(out globalVariables, 8, 4);
 
@@ -96,7 +97,7 @@ namespace ProtoTest.UtilsTests
                 over = A.B(1..8..1);
 ";
 
-            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core);
+            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core, out compileState);
             List<string> globalVariables = null;
             mirror.GetCoreDump(out globalVariables, 7, 4);
 
@@ -118,7 +119,7 @@ namespace ProtoTest.UtilsTests
                 x = a.x;
                 a.x = a;";
 
-            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core);
+            ExecutionMirror mirror = coreRunner.Execute(sourceCode, core, out compileState);
             List<string> globalVariables = null;
             mirror.GetCoreDump(out globalVariables, 7, 4);
 

--- a/Tests/ProtoTestFx/DebugService.cs
+++ b/Tests/ProtoTestFx/DebugService.cs
@@ -66,7 +66,7 @@ namespace ProtoTestFx
                 options.IncludeDirectories.Add(incDir);
 
                 core = new ProtoCore.Core(options);
-                core.BuildStatus.SetStream(stringStream);
+                //core.BuildStatus.SetStream(stringStream);
                 core.Options.RootModulePathName = ProtoCore.Utils.FileUtils.GetFullPathName(dsPath);
                 core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
                 core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
@@ -112,7 +112,7 @@ namespace ProtoTestFx
             {
                 if (core != null)
                 {
-                    core.BuildStatus.SetStream(null);
+                    //core.BuildStatus.SetStream(null);
                     core.Cleanup();
                 }
             }
@@ -138,7 +138,7 @@ namespace ProtoTestFx
             try
             {
                 core = new ProtoCore.Core(new ProtoCore.Options());
-                core.BuildStatus.SetStream(stringStream);
+                //core.BuildStatus.SetStream(stringStream);
                 core.Options.RootModulePathName = ProtoCore.Utils.FileUtils.GetFullPathName(dsPath);
                 core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
                 core.Executives.Add(ProtoCore.Language.kImperative, new ProtoImperative.Executive(core));
@@ -201,7 +201,7 @@ namespace ProtoTestFx
             {
                 if (core != null)
                 {
-                    core.BuildStatus.SetStream(null);                    
+                    //core.BuildStatus.SetStream(null);                    
                 }
             }
 

--- a/Tests/ProtoTestFx/DebugTestFx.cs
+++ b/Tests/ProtoTestFx/DebugTestFx.cs
@@ -77,7 +77,8 @@ namespace ProtoTestFx
 
             //Run
 
-            fsr.Execute(code, core);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            fsr.Execute(code, core, out compileState);
 
             return core;
         }

--- a/Tests/ProtoTestFx/GeometryTestFrame.cs
+++ b/Tests/ProtoTestFx/GeometryTestFrame.cs
@@ -62,7 +62,7 @@ namespace ProtoTestFx
 
         internal static ProtoCore.Core TestRunnerRunOnly(string includePath, string code,
             Dictionary<int, List<string>> map, string geometryFactory,
-            string persistentManager, out ExecutionMirror mirror)
+            string persistentManager, out ExecutionMirror mirror, out ProtoLanguage.CompileStateTracker compileState)
         {
             ProtoCore.Core core;
             ProtoScript.Runners.ProtoScriptTestRunner fsr = new ProtoScriptTestRunner();
@@ -98,7 +98,7 @@ namespace ProtoTestFx
             // by overriding the POP_handler instruction - pratapa
             core.ExecutiveProvider = new InjectionExecutiveProvider();
 
-            core.BuildStatus.MessageHandler = fs;
+            //core.BuildStatus.MessageHandler = fs;
             core.RuntimeStatus.MessageHandler = fs;
 
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
@@ -110,8 +110,7 @@ namespace ProtoTestFx
             DLLFFIHandler.Register(FFILanguage.CSharp, new CSModuleHelper());
 
             //Run
-
-            mirror = fsr.Execute(code, core);
+            mirror = fsr.Execute(code, core, out compileState);
 
             //sw.Close();
 
@@ -129,7 +128,9 @@ namespace ProtoTestFx
             file.Close();
             InjectionExecutive.ExpressionMap.Clear();
             ExecutionMirror mirror;
-            Core core = TestRunnerRunOnly(includePath, code, map, "ManagedAsmGeometry.dll", "ManagedAsmPersistentManager.dll", out mirror);
+
+            ProtoLanguage.CompileStateTracker compileState = null;
+            Core core = TestRunnerRunOnly(includePath, code, map, "ManagedAsmGeometry.dll", "ManagedAsmPersistentManager.dll", out mirror, out compileState);
 
             try
             {
@@ -144,7 +145,7 @@ namespace ProtoTestFx
                 string logFile = Path.GetFileName(Path.ChangeExtension(scriptFile, ".log"));
                 string baseLogFile = Path.Combine(BaseDir, logFile);
                 string outputLogFile = Path.Combine(ScriptDir, logFile);
-                TextOutputStream tStream = core.BuildStatus.MessageHandler as TextOutputStream;
+                TextOutputStream tStream = compileState.BuildStatus.MessageHandler as TextOutputStream;
                 StreamWriter osw = new StreamWriter(outputLogFile);
                 osw.Write(tStream.ToString());
                 if (null != mirror)
@@ -194,7 +195,8 @@ namespace ProtoTestFx
             file.Close();
             InjectionExecutive.ExpressionMap.Clear();
             ExecutionMirror mirror;
-            Core core = TestRunnerRunOnly(includePath, code, map, "ManagedAsmGeometry.dll", "ManagedAsmPersistentManager.dll", out mirror);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            Core core = TestRunnerRunOnly(includePath, code, map, "ManagedAsmGeometry.dll", "ManagedAsmPersistentManager.dll", out mirror, out compileState);
 
             //XML Result
             Dictionary<Expression, List<string>> expressionValues = InjectionExecutive.ExpressionMap;
@@ -207,7 +209,7 @@ namespace ProtoTestFx
             string logFile = Path.GetFileName(Path.ChangeExtension(scriptFile, ".log"));
             string baseLogFile = Path.Combine(BaseDir, logFile);
             string outputLogFile = Path.Combine(ScriptDir, logFile);
-            TextOutputStream tStream = core.BuildStatus.MessageHandler as TextOutputStream;
+            TextOutputStream tStream = compileState.BuildStatus.MessageHandler as TextOutputStream;
             StreamWriter osw = new StreamWriter(outputLogFile);
             osw.Write(tStream.ToString());
             if (null != mirror)
@@ -243,7 +245,8 @@ namespace ProtoTestFx
             file.Close();
             InjectionExecutive.ExpressionMap.Clear();
             ExecutionMirror mirror;
-            Core core = TestRunnerRunOnly(includePath, code, map, geometryFactory, persistentManager, out mirror);
+            ProtoLanguage.CompileStateTracker compileState = null;
+            Core core = TestRunnerRunOnly(includePath, code, map, geometryFactory, persistentManager, out mirror, out compileState);
 
             //XML Result
             Dictionary<Expression, List<string>> expressionValues = InjectionExecutive.ExpressionMap;
@@ -254,7 +257,7 @@ namespace ProtoTestFx
             //Log
             string logFile = Path.GetFileName(Path.ChangeExtension(scriptFile, ".log"));
             string outputLogFile = Path.Combine(outputDir, logFile);
-            TextOutputStream tStream = core.BuildStatus.MessageHandler as TextOutputStream;
+            TextOutputStream tStream = compileState.BuildStatus.MessageHandler as TextOutputStream;
             StreamWriter osw = new StreamWriter(outputLogFile);
             osw.Write(tStream.ToString());
             if (null != mirror)

--- a/Tests/ProtoTestFx/TestFrameWork.cs
+++ b/Tests/ProtoTestFx/TestFrameWork.cs
@@ -18,6 +18,7 @@ namespace ProtoTestFx.TD
     public class TestFrameWork
     {
         private static ProtoCore.Core testCore;
+        private static ProtoLanguage.CompileStateTracker compileState = null;
         private ExecutionMirror testMirror;
         private readonly ProtoScriptTestRunner runner;
         private static string mErrorMessage = "";
@@ -44,7 +45,6 @@ namespace ProtoTestFx.TD
             // this setting is to fix the random failure of replication test case
             testCore.Options.ExecutionMode = ProtoCore.ExecutionMode.Serial;
             testCore.Options.Verbose = true;
-//            testCore.Options.kDynamicCycleThreshold = 5;
             
             //FFI registration and cleanup
             DLLFFIHandler.Register(FFILanguage.CPlusPlus, new ProtoFFI.PInvokeModuleHelper());
@@ -230,7 +230,7 @@ namespace ProtoTestFx.TD
                         Console.WriteLine(String.Format("Path: {0} does not exist.", includePath));
                     }
                 }
-                testMirror = runner.Execute(sourceCode, testCore);
+                testMirror = runner.Execute(sourceCode, testCore, out compileState);
                 SetErrorMessage(errorstring);
                 return testMirror;
             }
@@ -540,12 +540,12 @@ namespace ProtoTestFx.TD
 
         public static void VerifyBuildWarning(ProtoCore.BuildData.WarningID id)
         {
-            Assert.IsTrue(testCore.BuildStatus.ContainsWarning(id), mErrorMessage);
+            Assert.IsTrue(compileState.BuildStatus.ContainsWarning(id), mErrorMessage);
         }
 
         public void VerifyBuildWarningCount(int count)
         {
-            Assert.IsTrue(testCore.BuildStatus.WarningCount == count, mErrorMessage);
+            Assert.IsTrue(compileState.BuildStatus.WarningCount == count, mErrorMessage);
         }
 
         public static void VerifyRuntimeWarning(ProtoCore.RuntimeData.WarningID id)

--- a/Tests/ProtoTestFx/WatchTestFx.cs
+++ b/Tests/ProtoTestFx/WatchTestFx.cs
@@ -59,7 +59,7 @@ namespace ProtoTestFx
             ProtoCore.DSASM.Mirror.ExecutionMirror mirror = new ProtoCore.DSASM.Mirror.ExecutionMirror(this, Core);
             string result = mirror.GetStringValue(sv, Core.Heap, 0, true);
 
-            TextOutputStream tStream = Core.BuildStatus.MessageHandler as TextOutputStream;
+            TextOutputStream tStream = Core.RuntimeStatus.MessageHandler as TextOutputStream;
             if (tStream != null)
             {
                 Dictionary<int, List<string>> map = tStream.Map;
@@ -333,7 +333,7 @@ namespace ProtoTestFx
             // by overriding the POP_handler instruction - pratapa
             core.ExecutiveProvider = new InjectionExecutiveProvider();
 
-            core.BuildStatus.MessageHandler = fs;
+            //core.BuildStatus.MessageHandler = fs;
             core.RuntimeStatus.MessageHandler = fs;
 
             core.Executives.Add(ProtoCore.Language.kAssociative, new ProtoAssociative.Executive(core));
@@ -343,10 +343,10 @@ namespace ProtoTestFx
             runnerConfig.IsParrallel = false;
             
             DLLFFIHandler.Register(FFILanguage.CSharp, new CSModuleHelper());
-            
-            //Run
 
-            Mirror = fsr.Execute(code, core);
+            //Run
+            ProtoLanguage.CompileStateTracker compileState = null;
+            Mirror = fsr.Execute(code, core, out compileState);
 
             //sw.Close();
             core.Cleanup();

--- a/UIs/Editor/DesignScriptEditor/DesignScriptEditorCore/Solution/VirtualMachineWorker.cs
+++ b/UIs/Editor/DesignScriptEditor/DesignScriptEditorCore/Solution/VirtualMachineWorker.cs
@@ -73,6 +73,7 @@ namespace DesignScript.Editor.Core
         DebugRunner debugRunner = null;
 
         // For script execution without debugger attached.
+        ProtoLanguage.CompileStateTracker compileState = null;
         ProtoCore.Core core = null;
         ProtoScriptTestRunner scriptRunner = null;
 
@@ -535,7 +536,6 @@ namespace DesignScript.Editor.Core
             }
 
             IOutputStream messageList = Solution.Current.GetMessage(false);
-            this.core.BuildStatus.MessageHandler = messageList;
             this.core.RuntimeStatus.MessageHandler = messageList;
 
             workerParams.RegularRunMirror = null;
@@ -587,7 +587,7 @@ namespace DesignScript.Editor.Core
 
             try
             {
-                workerParams.RegularRunMirror = scriptRunner.Execute(scriptCode, core);
+                workerParams.RegularRunMirror = scriptRunner.Execute(scriptCode, core, out compileState);
             }
             catch (System.Exception exception)
             {
@@ -770,11 +770,9 @@ namespace DesignScript.Editor.Core
             currentWatchedStackValue = null;
             ExpressionInterpreterRunner exprInterpreter = null;
 
-            IOutputStream buildStream = core.BuildStatus.MessageHandler;
             IOutputStream runtimeStream = core.RuntimeStatus.MessageHandler;
 
             // Disable output before interpret expression.
-            core.BuildStatus.MessageHandler = null;
             core.RuntimeStatus.MessageHandler = null;
             exprInterpreter = new ExpressionInterpreterRunner(this.core);
 
@@ -798,7 +796,6 @@ namespace DesignScript.Editor.Core
             }
 
             // Re-enable output after execution is done.
-            core.BuildStatus.MessageHandler = buildStream;
             core.RuntimeStatus.MessageHandler = runtimeStream;
             return (null != currentWatchedStackValue);
         }


### PR DESCRIPTION
1. Integration of CompileState  into the testframework so the tests can
   inspect compilation status
2. Remove BuildStatus from Core as it is only used at compile time
