### PR TITLE
remove ProtoLanguage from mono

### DIFF
--- a/DesignScriptLanguageMono.sln
+++ b/DesignScriptLanguageMono.sln
@@ -19,8 +19,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphToDSCompilerMono", "Co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExperimentalMono", "Libraries\Experimental\ExperimentalMono.csproj", "{E88B55C3-216B-4B4C-B46A-EC208D3520C7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProtoLanguageMono", "Core\ProtoLanguage\ProtoLanguageMono.csproj", "{0B6E0267-D83F-49EA-A658-79AFDC534C14}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProtoScriptMono", "Core\ProtoScript\ProtoScriptMono.csproj", "{A4794476-7D0E-41C0-AD83-4AB929C0A46C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StringMono", "Libraries\String\StringMono.csproj", "{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}"
@@ -172,21 +170,6 @@ Global
 		{E88B55C3-216B-4B4C-B46A-EC208D3520C7}.Release|Win32.ActiveCfg = Release|Any CPU
 		{E88B55C3-216B-4B4C-B46A-EC208D3520C7}.Release|x64.ActiveCfg = Release|Any CPU
 		{E88B55C3-216B-4B4C-B46A-EC208D3520C7}.Release|x86.ActiveCfg = Release|Any CPU
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|Any CPU.Build.0 = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|Mixed Platforms.ActiveCfg = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|Mixed Platforms.Build.0 = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|Win32.ActiveCfg = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|x64.ActiveCfg = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|x64.Build.0 = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Debug|x86.ActiveCfg = Debug|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|Any CPU.ActiveCfg = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|Mixed Platforms.ActiveCfg = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|Mixed Platforms.Build.0 = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|Win32.ActiveCfg = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|x64.ActiveCfg = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|x64.Build.0 = Release|x64
-		{0B6E0267-D83F-49EA-A658-79AFDC534C14}.Release|x86.ActiveCfg = Release|x64
 		{A4794476-7D0E-41C0-AD83-4AB929C0A46C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A4794476-7D0E-41C0-AD83-4AB929C0A46C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A4794476-7D0E-41C0-AD83-4AB929C0A46C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -206,19 +189,15 @@ Global
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|Win32.ActiveCfg = Debug|Any CPU
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x64.ActiveCfg = Debug|x64
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x64.Build.0 = Debug|x64
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x86.ActiveCfg = Debug|x86
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x86.Build.0 = Debug|x86
+		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|Win32.ActiveCfg = Release|Any CPU
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x64.ActiveCfg = Release|x64
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x64.Build.0 = Release|x64
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x86.ActiveCfg = Release|x86
-		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x86.Build.0 = Release|x86
+		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7A2F2EF-57FE-4C52-BA46-BDBE9E48A76A}.Release|x86.ActiveCfg = Release|Any CPU
 		{202F4D97-6343-4A47-AE44-B4EC4C91C3DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{202F4D97-6343-4A47-AE44-B4EC4C91C3DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{202F4D97-6343-4A47-AE44-B4EC4C91C3DF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
Accidentally submitted DesignScriptLanguage solution instead of mono in my previous submission
this is the correct submission for mono
