### PR TITLE
Clean up of ProtoScript.Runners.Obsolete namespace 

### DIFF
--- a/Core/ProtoScript/Runners/LiveRunner.cs
+++ b/Core/ProtoScript/Runners/LiveRunner.cs
@@ -77,7 +77,6 @@ namespace ProtoScript.Runners
         void UpdateGraph(GraphSyncData syncData);
         void UpdateCmdLineInterpreter(string code);
         ProtoCore.Mirror.RuntimeMirror QueryNodeValue(Guid nodeId);
-        //ProtoCore.Mirror.RuntimeMirror QueryNodeValue(string nodeName);
         ProtoCore.Mirror.RuntimeMirror InspectNodeValue(string nodeName);
         #endregion
 

--- a/Core/ProtoScript/Runners/LiveRunnerTasks.cs
+++ b/Core/ProtoScript/Runners/LiveRunnerTasks.cs
@@ -595,52 +595,6 @@ namespace ProtoScript.Runners
                 }
             }
 
-            private class UpdateCmdLineInterpreterTask : Task
-            {
-                private string cmdLineString;
-                public UpdateCmdLineInterpreterTask(string code, LiveRunner runner)
-                    : base(runner)
-                {
-                    this.cmdLineString = code;
-                }
-
-                public override void Execute()
-                {
-                    GraphUpdateReadyEventArgs retArgs = null;
-
-                    lock (runner.operationsMutex)
-                    {
-                        try
-                        {
-                            string code = null;
-                            runner.SynchronizeInternal(code);
-
-                            var modfiedGuidList = runner.GetModifiedGuidList();
-                            runner.ResetModifiedSymbols();
-                            var syncDataReturn = runner.CreateSynchronizeDataForGuidList(modfiedGuidList);
-
-                            retArgs = null;
-
-                            // TODO: Implement ReportErrors override to report errors for command line statements
-                            //ReportErrors(code, syncDataReturn, modfiedGuidList, ref retArgs);
-
-                            if (retArgs == null)
-                                retArgs = new GraphUpdateReadyEventArgs(syncDataReturn);
-                        }
-                        // Any exceptions that are caught here are most likely from the graph compiler
-                        catch (Exception e)
-                        {
-                            //retArgs = new GraphUpdateReadyEventArgs(syncData, EventStatus.Error, e.Message);
-                        }
-                    }
-
-                    if (runner.GraphUpdateReady != null)
-                    {
-                        runner.GraphUpdateReady(this, retArgs); // Notify all listeners (e.g. UI).
-                    }
-                }
-
-            }
 
             private class ConvertNodesToCodeTask : Task
             {


### PR DESCRIPTION
Clean up of ProtoScript.Runners.Obsolete namespace for API's only being used by the new LiveRunner
