### PR TITLE
Assign the expression id of the node before SSA transformation

### DIFF
--- a/Core/ProtoAssociative/CodeGen.cs
+++ b/Core/ProtoAssociative/CodeGen.cs
@@ -3455,10 +3455,16 @@ namespace ProtoAssociative
                             foreach (AssociativeNode aNode in newASTList)
                             {
                                 Debug.Assert(aNode is BinaryExpressionNode);
-                                bnode = aNode as BinaryExpressionNode;
-                                bnode.exprUID = ssaID;
-                                NodeUtils.SetNodeLocation(bnode, node, node);
+
+                                // Set the exprID of the SSA's node
+                                BinaryExpressionNode ssaNode = aNode as BinaryExpressionNode;
+                                ssaNode.exprUID = ssaID;
+                                NodeUtils.SetNodeLocation(ssaNode, node, node);
                             }
+
+                            // Assigne the exprID of the original node 
+                            // (This is the node prior to ssa transformation)
+                            bnode.exprUID = ssaID;
                             newAstList.AddRange(newASTList);
                         }
                         else


### PR DESCRIPTION
This information is required by the delta execution when marking
previous graphnodes inactive but is unused by the compiler and runtime
