### PR TITLE
Fix build on DSS due to function name change in the GraphUtiltities

### DIFF
--- a/UIs/Studio/DesignScriptStudio.Graph.Core/CoreComponent.cs
+++ b/UIs/Studio/DesignScriptStudio.Graph.Core/CoreComponent.cs
@@ -293,7 +293,7 @@ namespace DesignScriptStudio.Graph.Core
         {
             if (null != coreComponent)
             {
-                GraphToDSCompiler.GraphUtilities.CleanUp();
+                GraphToDSCompiler.GraphUtilities.Reset();
                 coreComponent.Shutdown();
                 coreComponent = null;
             }


### PR DESCRIPTION
This submission does not require a DesignScript dll update in dynamo as we do not use DSS dlls there.
