### PR TITLE
Add StartUp() and ShutDown() methods to HostFactory

### DIFF
--- a/Libraries/ProtoGeometry/Core/HostFactory.cs
+++ b/Libraries/ProtoGeometry/Core/HostFactory.cs
@@ -9,7 +9,8 @@ using System.Configuration;
 
 namespace Autodesk.DesignScript.Geometry
 {
-    class HostFactory
+    [Browsable(false)]
+    public class HostFactory
     {
 
         #region PRIVATE_METHODS
@@ -91,6 +92,24 @@ namespace Autodesk.DesignScript.Geometry
                     System.Diagnostics.Debug.Write(ex.InnerException);
                 System.Diagnostics.Debug.Write(ex);
                 mErrorString = ex.Message;
+            }
+        }
+
+        // Explicitly start up geometry extension application.
+        public void StartUp()
+        {
+            foreach (IExtensionApplication app in mExtensionApplications)
+            {
+                app.StartUp();
+            }
+        }
+
+        // Explicity shut down geometry extension application.
+        public void ShutDown()
+        {
+            foreach (IExtensionApplication app in mExtensionApplications)
+            {
+                app.ShutDown();
             }
         }
 
@@ -189,7 +208,7 @@ namespace Autodesk.DesignScript.Geometry
 
         //Double check locking for multi-threaded singleton class.
         private static readonly Object syncRoot = new Object();
-        private static HostFactory Instance
+        public static HostFactory Instance
         {
             get
             {


### PR DESCRIPTION
This is to fix the ProtoGeometry to RevitGeometry test case issue. 

The related update in Dynamo: https://github.com/ikeough/Dynamo/pull/922
