### PR TITLE
Optimize node re-execution on function redefinition

### DIFF
--- a/Core/ProtoAssociative/CodeGen.cs
+++ b/Core/ProtoAssociative/CodeGen.cs
@@ -6309,6 +6309,12 @@ namespace ProtoAssociative
                 {
                     graphNode.firstProc = procNode;
                     graphNode.firstProcRefIndex = graphNode.dependentList.Count - 1;
+
+                    // Memoize the graphnode that contains a user-defined function call
+                    if (!procNode.isExternal)
+                    {
+                        core.GraphNodeCallList.Add(graphNode);
+                    }
                 }
             }
             IsAssociativeArrayIndexing = arrayIndexing;
@@ -7821,7 +7827,6 @@ namespace ProtoAssociative
                 // Dependency graph construction is complete for this expression
                 graphNode.updateBlock.endpc = pc - 1;
                 codeBlock.instrStream.dependencyGraph.Push(graphNode);
-
                 functionCallStack.Clear();
             }
         }

--- a/Core/ProtoCore/Core.cs
+++ b/Core/ProtoCore/Core.cs
@@ -1112,6 +1112,9 @@ namespace ProtoCore
         public bool EnableCallsiteExecutionState { get; set; }
         public CallsiteExecutionState csExecutionState { get; set; }
 
+        // A list of graphnodes that contain a function call
+        public List<AssociativeGraph.GraphNode> GraphNodeCallList { get; set; }
+
         /// <summary>
         /// Sets the function to an inactive state where it can no longer be used by the front-end and backend
         /// </summary>
@@ -1355,6 +1358,9 @@ namespace ProtoCore
             {
                 CodeBlockList[n].instrStream.instrList.Clear();
             }
+
+            // Remove inactive graphnodes in the list
+            GraphNodeCallList.RemoveAll(g => !g.isActive);
         }
 
         public void ResetForDeltaASTExecution()
@@ -1648,6 +1654,8 @@ namespace ProtoCore
                 csExecutionState = new CallsiteExecutionState();
             }
             ForLoopBlockIndex = ProtoCore.DSASM.Constants.kInvalidIndex;
+
+            GraphNodeCallList = new List<GraphNode>();
         }
 
         // The unique subscript for SSA temporaries

--- a/Core/ProtoScript/Runners/LiveRunner.cs
+++ b/Core/ProtoScript/Runners/LiveRunner.cs
@@ -784,16 +784,17 @@ namespace ProtoScript.Runners
             }
         }
 
-        private List<AssociativeNode> GetASTNodesDependentOnFunctionList(List<FunctionDefinitionNode> fnodeList)
+        private List<AssociativeNode> GetASTNodesDependentOnFunctionList(FunctionDefinitionNode functionNode)
         {
             // Determine if the modified function was used in any of the current nodes
             List<AssociativeNode> modifiedNodes = new List<AssociativeNode>();
 
-            // Iterate through the vm graphnodes at the global scope
-            foreach (ProtoCore.AssociativeGraph.GraphNode gnode in runnerCore.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
+            // Iterate through the vm graphnodes at the global scope that contain a function call
+            //foreach (ProtoCore.AssociativeGraph.GraphNode gnode in runnerCore.DSExecutable.instrStreamList[0].dependencyGraph.GraphList)
+            Validity.Assert(null != runnerCore.GraphNodeCallList);
+            foreach (ProtoCore.AssociativeGraph.GraphNode gnode in runnerCore.GraphNodeCallList)
             {
-                // For every function in the modified function list
-                foreach (FunctionDefinitionNode fnode in fnodeList)
+                if (gnode.isActive)
                 {
                     // Iterate through the current ast nodes 
                     foreach (KeyValuePair<System.Guid, Subtree> kvp in currentSubTreeList)
@@ -807,8 +808,8 @@ namespace ProtoScript.Runners
                                     // Check if the procedure associatied with this graphnode matches thename and arg count of the modified proc
                                     if (null != gnode.firstProc)
                                     {
-                                        if (gnode.firstProc.name == fnode.Name
-                                            && gnode.firstProc.argInfoList.Count == fnode.Signature.Arguments.Count)
+                                        if (gnode.firstProc.name == functionNode.Name
+                                            && gnode.firstProc.argInfoList.Count == functionNode.Signature.Arguments.Count)
                                         {
                                             // If it does, create a new ast tree for this graphnode and append it to deltaAstList
                                             modifiedNodes.Add(assocNode);
@@ -1073,7 +1074,13 @@ namespace ProtoScript.Runners
                         currentSubTreeList[st.GUID] = st;
                     }
 
-                    deltaAstList.AddRange(GetASTNodesDependentOnFunctionList(modifiedFunctions));
+                    
+                    // Get the AST's dependent on every function in the modified function list,
+                    // and append them to the list of AST's to be compiled and executed
+                    foreach (FunctionDefinitionNode fnode in modifiedFunctions)
+                    {
+                        deltaAstList.AddRange(GetASTNodesDependentOnFunctionList(fnode));
+                    }
                 }
             }
 


### PR DESCRIPTION
1. Memoize the graphnodes in a list that contain user-defined function
   calls
2. Refer to the graphnode list when selecting nodes to re-execute
3. Function redefinition test cases for overloaded functions
