### PR TITLE
Update AstFactory.BuildFunctionCall()

### DIFF
--- a/Core/ProtoCore/Parser/AssociativeAST.cs
+++ b/Core/ProtoCore/Parser/AssociativeAST.cs
@@ -1990,25 +1990,26 @@ namespace ProtoCore.AST.AssociativeAST
             return cond;
         }
 
-        public static AssociativeNode BuildFunctionCall(string function,
-                                                        List<AssociativeNode> arguments, Core core = null)
+        public static AssociativeNode BuildFunctionCall(string className,
+                                                        string functionName,
+                                                        List<AssociativeNode> arguments, 
+                                                        Core core = null)
         {
-            string[] dotcalls = function.Split('.');
-            string functionName = dotcalls[dotcalls.Length - 1];
+            return new IdentifierListNode
+            {
+                LeftNode = new IdentifierNode(className),
+                RightNode = AstFactory.BuildFunctionCall(functionName, arguments)
+            };
+        }
 
+        public static AssociativeNode BuildFunctionCall(string functionName,
+                                                        List<AssociativeNode> arguments,
+                                                        Core core = null)
+        {
             FunctionCallNode funcCall = new FunctionCallNode();
             funcCall.Function = BuildIdentifier(functionName);
             funcCall.FormalArguments = arguments;
-
-            if (dotcalls.Length == 1)
-            {
-                return funcCall;
-            }
-            else
-            {
-                IdentifierNode lhs = BuildIdentifier(dotcalls[0]);
-                return CoreUtils.GenerateCallDotNode(lhs, funcCall, core);
-            }
+            return funcCall;
         }
 
         public static IdentifierNode BuildIdentifier(string name)


### PR DESCRIPTION
BuildFunctionCall() won't split the input function name by delimiter '.' . 

The related pull request for Dynamo is https://github.com/ikeough/Dynamo/pull/1060
